### PR TITLE
Upgrade Go to v1.20.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/test-network-function/graphsolver-lib
 
-go 1.19
+go 1.20
 
 require (
 	github.com/sirupsen/logrus v1.9.0


### PR DESCRIPTION
Release Notes: https://tip.golang.org/doc/go1.20

Related to: https://github.com/test-network-function/cnf-certification-test/pull/873