### PR TITLE
Update Go to v1.21.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/test-network-function/graphsolver-lib
 
-go 1.20
+go 1.21
 
 require (
 	github.com/sirupsen/logrus v1.9.0


### PR DESCRIPTION
https://go.dev/doc/go1.21

Related to: https://github.com/test-network-function/cnf-certification-test/pull/1344